### PR TITLE
Add Support for New Xiaomi Wifi Bedside Light

### DIFF
--- a/yeelight/index.js
+++ b/yeelight/index.js
@@ -79,7 +79,7 @@ YeePlatform.prototype = {
                 .on('set', function(value, callback) { that.exeCmd(dev.did, "brightness", value, callback);})
                 .value = dev.bright;
 
-            if (dev.model == "color" || dev.model == "stripe" || dev.model == "bedside") {
+            if (dev.model == "color" || dev.model == "stripe" || dev.model == "bedside" || dev.model == "bslamp1") {
                 lightbulbService
                     .addCharacteristic(Characteristic.Hue)
                     .on('set', function(value, callback) { that.exeCmd(dev.did, "hue", value, callback);})
@@ -96,7 +96,7 @@ YeePlatform.prototype = {
                 .on('set', function(value, callback) { that.exeCmd(dev.did, "brightness", value, callback);})
                 .value = dev.bright;
 
-            if (dev.model == "color" || dev.model == "stripe" || dev.model == "bedside") {
+            if (dev.model == "color" || dev.model == "stripe" || dev.model == "bedside" || dev.model == "bslamp1") {
                 lightbulbService
                     .getCharacteristic(Characteristic.Hue)
                     .on('set', function(value, callback) { that.exeCmd(dev.did, "hue", value, callback);})


### PR DESCRIPTION
bslamp1 is the device model sent by the Xiaomi Mi Bedside Light Wifi model being sold in North America. Its also possibly the string being sent down by older models with the latest firmware update. This update should fix the Hue/Saturation support.